### PR TITLE
fix: enable preserveConstEnums

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
         "resolveJsonModule": true,
-        "preserveConstEnums": true, /* https://github.com/fb55/domelementtype/pull/18#issuecomment-804507896 */
+        "preserveConstEnums": true /* https://github.com/fb55/domelementtype/pull/18#issuecomment-804507896 */
     },
     "include": ["src"],
     "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
         /* Module Resolution Options */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "preserveConstEnums": true, /* https://github.com/fb55/domelementtype/pull/18#issuecomment-804507896 */
     },
     "include": ["src"],
     "exclude": [


### PR DESCRIPTION
Per suggestion by @fb55 in #18 I've enabled the `preserveConstEnums` compiler flag. Output appears to be very similar to that produced by the #18 PR, but not identical. The main difference being that this approach stringifies usages of the enum, where as #18 uses the enum directly. 

IE
```js
exports.Root = "root" /* Root */;
// vs
exports.Root = ElementType.Root;
```

Personally I think the other produces the better of the two outputs but I'll defer to you.

```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.Doctype = exports.CDATA = exports.Tag = exports.Style = exports.Script = exports.Comment = exports.Directive = exports.Text = exports.Root = exports.isTag = exports.ElementType = void 0;
/** Types of elements found in htmlparser2's DOM */
var ElementType;
(function (ElementType) {
    /** Type for the root element of a document */
    ElementType["Root"] = "root";
    /** Type for Text */
    ElementType["Text"] = "text";
    /** Type for <? ... ?> */
    ElementType["Directive"] = "directive";
    /** Type for <!-- ... --> */
    ElementType["Comment"] = "comment";
    /** Type for <script> tags */
    ElementType["Script"] = "script";
    /** Type for <style> tags */
    ElementType["Style"] = "style";
    /** Type for Any tag */
    ElementType["Tag"] = "tag";
    /** Type for <![CDATA[ ... ]]> */
    ElementType["CDATA"] = "cdata";
    /** Type for <!doctype ...> */
    ElementType["Doctype"] = "doctype";
})(ElementType = exports.ElementType || (exports.ElementType = {}));
/**
 * Tests whether an element is a tag or not.
 *
 * @param elem Element to test
 */
function isTag(elem) {
    return (elem.type === "tag" /* Tag */ ||
        elem.type === "script" /* Script */ ||
        elem.type === "style" /* Style */);
}
exports.isTag = isTag;
// Exports for backwards compatibility
/** Type for the root element of a document */
exports.Root = "root" /* Root */;
/** Type for Text */
exports.Text = "text" /* Text */;
/** Type for <? ... ?> */
exports.Directive = "directive" /* Directive */;
/** Type for <!-- ... --> */
exports.Comment = "comment" /* Comment */;
/** Type for <script> tags */
exports.Script = "script" /* Script */;
/** Type for <style> tags */
exports.Style = "style" /* Style */;
/** Type for Any tag */
exports.Tag = "tag" /* Tag */;
/** Type for <![CDATA[ ... ]]> */
exports.CDATA = "cdata" /* CDATA */;
/** Type for <!doctype ...> */
exports.Doctype = "doctype" /* Doctype */;

```