### PR TITLE
chore: use HTTPS repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git://github.com/fb55/domelementtype.git"
+        "url": "https://github.com/fb55/domelementtype.git"
     },
     "keywords": [
         "dom",


### PR DESCRIPTION
Updates the package repository metadata to use HTTPS instead of the unauthenticated `git://` protocol.

Validation:
- `git diff --check`
- parsed the changed `package.json` file(s) with Node.js